### PR TITLE
Update UI theme and layout

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -9,6 +9,7 @@ import 'providers/sleep_tracking_provider.dart';
 import 'screens/home_screen.dart';
 import 'screens/sleep_analysis_screen.dart';
 import 'screens/sound_events_screen.dart';
+import 'utils/app_theme.dart';
 
 /// エントリポイント。アプリを起動する
 void main() {
@@ -28,10 +29,10 @@ class SleepCycleApp extends StatelessWidget {
         theme: ThemeData(
           useMaterial3: true,
           colorScheme: ColorScheme.fromSeed(
-            seedColor: const Color(0xFF4A90E2),
+            seedColor: AppTheme.accent,
             brightness: Brightness.dark,
           ),
-          scaffoldBackgroundColor: const Color(0xFF1A1A2E),
+          scaffoldBackgroundColor: AppTheme.background,
         ),
         home: const MainScreen(),
         debugShowCheckedModeBanner: false,
@@ -63,8 +64,8 @@ class _MainScreenState extends State<MainScreen> {
     return Scaffold(
       body: _screens[_currentIndex],
       bottomNavigationBar: BottomNavigationBar(
-        backgroundColor: const Color(0xFF1A1A2E),
-        selectedItemColor: const Color(0xFF4A90E2),
+        backgroundColor: AppTheme.background,
+        selectedItemColor: AppTheme.accent,
         unselectedItemColor: Colors.grey,
         currentIndex: _currentIndex,
         onTap: (index) {

--- a/lib/main_new.dart
+++ b/lib/main_new.dart
@@ -6,6 +6,7 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'providers/sleep_tracking_provider.dart';
 import 'screens/home_screen.dart';
+import 'utils/app_theme.dart';
 
 /// テスト用エントリポイント
 void main() {
@@ -25,10 +26,10 @@ class SleepCycleApp extends StatelessWidget {
         theme: ThemeData(
           useMaterial3: true,
           colorScheme: ColorScheme.fromSeed(
-            seedColor: const Color(0xFF4A90E2),
+            seedColor: AppTheme.accent,
             brightness: Brightness.dark,
           ),
-          scaffoldBackgroundColor: const Color(0xFF1A1A2E),
+          scaffoldBackgroundColor: AppTheme.background,
         ),
         home: const HomeScreen(),
         debugShowCheckedModeBanner: false,

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -11,6 +11,7 @@ import '../models/sleep_data.dart';
 import '../utils/permission_helper.dart';
 import 'sleep_analysis_screen.dart';
 import 'sound_events_screen.dart';
+import '../utils/app_theme.dart';
 
 class HomeScreen extends StatefulWidget {
   const HomeScreen({super.key});
@@ -72,7 +73,7 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
   /// ホーム画面全体のUIを構築する
   Widget build(BuildContext context) {
     return Scaffold(
-      backgroundColor: const Color(0xFF1A1A2E),
+      backgroundColor: AppTheme.background,
       body: Consumer<SleepTrackingProvider>(
         builder: (context, provider, child) {
           return SafeArea(
@@ -102,21 +103,31 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
       alignment: Alignment.center,
       child: Column(
         children: [
-          const Icon(Icons.bedtime, size: 48, color: Color(0xFF4A90E2)),
-          const SizedBox(height: 16),
+          StreamBuilder<DateTime>(
+            stream: Stream.periodic(
+              const Duration(seconds: 1),
+              (_) => DateTime.now(),
+            ),
+            builder: (context, snapshot) {
+              final now = snapshot.data ?? DateTime.now();
+              final time =
+                  '${now.hour.toString().padLeft(2, '0')}:${now.minute.toString().padLeft(2, '0')}';
+              return Text(
+                time,
+                style: const TextStyle(
+                  fontSize: 48,
+                  fontWeight: FontWeight.w500,
+                  color: Colors.white,
+                ),
+              );
+            },
+          ),
+          const SizedBox(height: 8),
           const Text(
             'Sleep Tracker',
             style: TextStyle(
-              fontSize: 28,
-              fontWeight: FontWeight.bold,
-              color: Colors.white,
-            ),
-          ),
-          Text(
-            '睡眠の質を分析してより良い睡眠を',
-            style: TextStyle(
-              fontSize: 16,
-              color: Colors.white.withOpacity(0.7),
+              fontSize: 20,
+              color: Colors.white54,
             ),
           ),
         ],
@@ -172,7 +183,7 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
 
         if (provider.isAnalyzing) ...[
           const CircularProgressIndicator(
-            valueColor: AlwaysStoppedAnimation<Color>(Color(0xFF4A90E2)),
+            valueColor: AlwaysStoppedAnimation<Color>(AppTheme.accent),
           ),
           const SizedBox(height: 24),
           Text(
@@ -188,11 +199,11 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
               shape: BoxShape.circle,
               color: provider.isRecording
                   ? const Color(0xFFE74C3C).withOpacity(0.2)
-                  : const Color(0xFF4A90E2).withOpacity(0.2),
+                  : AppTheme.accent.withOpacity(0.2),
               border: Border.all(
                 color: provider.isRecording
                     ? const Color(0xFFE74C3C)
-                    : const Color(0xFF4A90E2),
+                    : AppTheme.accent,
                 width: 3,
               ),
             ),
@@ -210,7 +221,7 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
                         size: 64,
                         color: provider.isRecording
                             ? const Color(0xFFE74C3C)
-                            : const Color(0xFF4A90E2),
+                            : AppTheme.accent,
                       ),
                       const SizedBox(height: 16),
                       Text(
@@ -220,7 +231,7 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
                           fontWeight: FontWeight.bold,
                           color: provider.isRecording
                               ? const Color(0xFFE74C3C)
-                              : const Color(0xFF4A90E2),
+                              : AppTheme.accent,
                         ),
                       ),
                     ],
@@ -280,10 +291,10 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
       width: double.infinity,
       padding: const EdgeInsets.all(24),
       decoration: BoxDecoration(
-        color: const Color(0xFF16213E),
+        color: AppTheme.cardBackground,
         borderRadius: BorderRadius.circular(16),
         border: Border.all(
-          color: const Color(0xFF4A90E2).withOpacity(0.3),
+          color: AppTheme.accent.withOpacity(0.3),
           width: 1,
         ),
       ),
@@ -361,17 +372,17 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
     return Container(
       padding: const EdgeInsets.all(16),
       decoration: BoxDecoration(
-        color: const Color(0xFF16213E),
+        color: AppTheme.cardBackground,
         borderRadius: BorderRadius.circular(12),
         border: Border.all(
-          color: const Color(0xFF4A90E2).withOpacity(0.3),
+          color: AppTheme.accent.withOpacity(0.3),
           width: 1,
         ),
       ),
       child: Column(
         mainAxisAlignment: MainAxisAlignment.center,
         children: [
-          Icon(icon, size: 24, color: const Color(0xFF4A90E2)),
+          Icon(icon, size: 24, color: AppTheme.accent),
           const SizedBox(height: 8),
           Text(
             title,
@@ -407,10 +418,10 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
       width: double.infinity,
       padding: const EdgeInsets.all(20),
       decoration: BoxDecoration(
-        color: const Color(0xFF16213E),
+        color: AppTheme.cardBackground,
         borderRadius: BorderRadius.circular(16),
         border: Border.all(
-          color: const Color(0xFF4A90E2).withOpacity(0.3),
+          color: AppTheme.accent.withOpacity(0.3),
           width: 1,
         ),
       ),
@@ -462,10 +473,10 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
     return Container(
       padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
       decoration: BoxDecoration(
-        color: const Color(0xFF4A90E2).withOpacity(0.2),
+        color: AppTheme.accent.withOpacity(0.2),
         borderRadius: BorderRadius.circular(16),
         border: Border.all(
-          color: const Color(0xFF4A90E2).withOpacity(0.5),
+          color: AppTheme.accent.withOpacity(0.5),
           width: 1,
         ),
       ),
@@ -497,7 +508,7 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
             icon: const Icon(Icons.analytics),
             label: const Text('詳細分析を見る'),
             style: ElevatedButton.styleFrom(
-              backgroundColor: const Color(0xFF4A90E2),
+              backgroundColor: AppTheme.accent,
               foregroundColor: Colors.white,
               padding: const EdgeInsets.all(16),
               shape: RoundedRectangleBorder(
@@ -515,7 +526,7 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
             label: const Text('新しい記録を開始'),
             style: OutlinedButton.styleFrom(
               foregroundColor: Colors.white,
-              side: const BorderSide(color: Color(0xFF4A90E2)),
+              side: const BorderSide(color: AppTheme.accent),
               padding: const EdgeInsets.all(16),
               shape: RoundedRectangleBorder(
                 borderRadius: BorderRadius.circular(12),
@@ -564,7 +575,7 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
       label: const Text('睡眠履歴を見る'),
       style: OutlinedButton.styleFrom(
         foregroundColor: Colors.white,
-        side: const BorderSide(color: Color(0xFF4A90E2)),
+        side: const BorderSide(color: AppTheme.accent),
         padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 12),
         shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
       ),
@@ -621,7 +632,7 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
       case SleepQuality.excellent:
         return const Color(0xFF27AE60);
       case SleepQuality.good:
-        return const Color(0xFF4A90E2);
+        return AppTheme.accent;
       case SleepQuality.fair:
         return const Color(0xFFF39C12);
       case SleepQuality.poor:

--- a/lib/screens/sleep_analysis_screen.dart
+++ b/lib/screens/sleep_analysis_screen.dart
@@ -8,6 +8,7 @@ import 'package:provider/provider.dart';
 import 'package:fl_chart/fl_chart.dart';
 import '../providers/sleep_tracking_provider.dart';
 import '../models/sleep_data.dart';
+import '../utils/app_theme.dart';
 
 class SleepAnalysisScreen extends StatelessWidget {
   const SleepAnalysisScreen({super.key});
@@ -16,10 +17,10 @@ class SleepAnalysisScreen extends StatelessWidget {
   /// 分析画面のメインUIを構築
   Widget build(BuildContext context) {
     return Scaffold(
-      backgroundColor: const Color(0xFF1A1A2E),
+      backgroundColor: AppTheme.background,
       appBar: AppBar(
         title: const Text('睡眠分析'),
-        backgroundColor: const Color(0xFF16213E),
+        backgroundColor: AppTheme.cardBackground,
         foregroundColor: Colors.white,
         elevation: 0,
       ),
@@ -65,10 +66,10 @@ class SleepAnalysisScreen extends StatelessWidget {
       width: double.infinity,
       padding: const EdgeInsets.all(20),
       decoration: BoxDecoration(
-        color: const Color(0xFF16213E),
+        color: AppTheme.cardBackground,
         borderRadius: BorderRadius.circular(16),
         border: Border.all(
-          color: const Color(0xFF4A90E2).withOpacity(0.3),
+          color: AppTheme.accent.withOpacity(0.3),
           width: 1,
         ),
       ),
@@ -170,12 +171,12 @@ class SleepAnalysisScreen extends StatelessWidget {
       padding: const EdgeInsets.all(12),
       margin: const EdgeInsets.only(right: 8),
       decoration: BoxDecoration(
-        color: const Color(0xFF4A90E2).withOpacity(0.1),
+        color: AppTheme.accent.withOpacity(0.1),
         borderRadius: BorderRadius.circular(8),
       ),
       child: Row(
         children: [
-          Icon(icon, size: 16, color: const Color(0xFF4A90E2)),
+          Icon(icon, size: 16, color: AppTheme.accent),
           const SizedBox(width: 8),
           Expanded(
             child: Column(
@@ -210,10 +211,10 @@ class SleepAnalysisScreen extends StatelessWidget {
       width: double.infinity,
       padding: const EdgeInsets.all(20),
       decoration: BoxDecoration(
-        color: const Color(0xFF16213E),
+        color: AppTheme.cardBackground,
         borderRadius: BorderRadius.circular(16),
         border: Border.all(
-          color: const Color(0xFF4A90E2).withOpacity(0.3),
+          color: AppTheme.accent.withOpacity(0.3),
           width: 1,
         ),
       ),
@@ -321,10 +322,10 @@ class SleepAnalysisScreen extends StatelessWidget {
       width: double.infinity,
       padding: const EdgeInsets.all(20),
       decoration: BoxDecoration(
-        color: const Color(0xFF16213E),
+        color: AppTheme.cardBackground,
         borderRadius: BorderRadius.circular(16),
         border: Border.all(
-          color: const Color(0xFF4A90E2).withOpacity(0.3),
+          color: AppTheme.accent.withOpacity(0.3),
           width: 1,
         ),
       ),
@@ -428,7 +429,7 @@ class SleepAnalysisScreen extends StatelessWidget {
           LineChartBarData(
             spots: spots,
             isCurved: false,
-            color: const Color(0xFF4A90E2),
+            color: AppTheme.accent,
             barWidth: 2,
             dotData: FlDotData(
               show: true,
@@ -459,10 +460,10 @@ class SleepAnalysisScreen extends StatelessWidget {
       width: double.infinity,
       padding: const EdgeInsets.all(20),
       decoration: BoxDecoration(
-        color: const Color(0xFF16213E),
+        color: AppTheme.cardBackground,
         borderRadius: BorderRadius.circular(16),
         border: Border.all(
-          color: const Color(0xFF4A90E2).withOpacity(0.3),
+          color: AppTheme.accent.withOpacity(0.3),
           width: 1,
         ),
       ),
@@ -555,7 +556,7 @@ class SleepAnalysisScreen extends StatelessWidget {
       case SleepQuality.excellent:
         return const Color(0xFF27AE60);
       case SleepQuality.good:
-        return const Color(0xFF4A90E2);
+        return AppTheme.accent;
       case SleepQuality.fair:
         return const Color(0xFFF39C12);
       case SleepQuality.poor:

--- a/lib/screens/sound_events_screen.dart
+++ b/lib/screens/sound_events_screen.dart
@@ -8,6 +8,7 @@ import 'package:provider/provider.dart';
 import '../providers/sleep_tracking_provider.dart';
 import '../models/sleep_data.dart';
 import '../services/audio_player_service.dart';
+import '../utils/app_theme.dart';
 
 class SoundEventsScreen extends StatefulWidget {
   const SoundEventsScreen({super.key});
@@ -52,16 +53,16 @@ class _SoundEventsScreenState extends State<SoundEventsScreen>
   /// 音響イベント画面のUIを構築
   Widget build(BuildContext context) {
     return Scaffold(
-      backgroundColor: const Color(0xFF1A1A2E),
+      backgroundColor: AppTheme.background,
       appBar: AppBar(
         title: const Text('音響イベント'),
-        backgroundColor: const Color(0xFF16213E),
+        backgroundColor: AppTheme.cardBackground,
         foregroundColor: Colors.white,
         elevation: 0,
         bottom: TabBar(
           controller: _tabController,
           isScrollable: true,
-          indicatorColor: const Color(0xFF4A90E2),
+          indicatorColor: AppTheme.accent,
           labelColor: Colors.white,
           unselectedLabelColor: Colors.white60,
           onTap: (index) {
@@ -135,7 +136,7 @@ class _SoundEventsScreenState extends State<SoundEventsScreen>
         Container(
           width: double.infinity,
           padding: const EdgeInsets.all(16),
-          color: const Color(0xFF16213E),
+          color: AppTheme.cardBackground,
           child: Row(
             children: [
               Icon(_getTypeIcon(type), size: 24, color: _getTypeColor(type)),
@@ -188,10 +189,10 @@ class _SoundEventsScreenState extends State<SoundEventsScreen>
       margin: const EdgeInsets.only(bottom: 12),
       padding: const EdgeInsets.all(16),
       decoration: BoxDecoration(
-        color: const Color(0xFF16213E),
+        color: AppTheme.cardBackground,
         borderRadius: BorderRadius.circular(12),
         border: Border.all(
-          color: isPlaying ? const Color(0xFF4A90E2) : Colors.transparent,
+          color: isPlaying ? AppTheme.accent : Colors.transparent,
           width: 2,
         ),
       ),
@@ -276,14 +277,14 @@ class _SoundEventsScreenState extends State<SoundEventsScreen>
 
     return Container(
       decoration: BoxDecoration(
-        color: const Color(0xFF4A90E2).withOpacity(0.2),
+        color: AppTheme.accent.withOpacity(0.2),
         shape: BoxShape.circle,
       ),
       child: IconButton(
         onPressed: () => _handlePlayButton(event),
         icon: Icon(
           isPlaying ? Icons.pause : Icons.play_arrow,
-          color: const Color(0xFF4A90E2),
+          color: AppTheme.accent,
         ),
         iconSize: 20,
       ),
@@ -306,7 +307,7 @@ class _SoundEventsScreenState extends State<SoundEventsScreen>
                   : 0,
               backgroundColor: Colors.white24,
               valueColor: const AlwaysStoppedAnimation<Color>(
-                Color(0xFF4A90E2),
+                AppTheme.accent,
               ),
             ),
             const SizedBox(height: 8),

--- a/lib/utils/app_theme.dart
+++ b/lib/utils/app_theme.dart
@@ -1,0 +1,7 @@
+import 'package:flutter/material.dart';
+
+class AppTheme {
+  static const Color background = Color(0xFF0A0A0A);
+  static const Color cardBackground = Color(0xFF1C1C1E);
+  static const Color accent = Color(0xFFFF9500);
+}


### PR DESCRIPTION
## Summary
- refresh theme to match SleepCycle style using orange accent
- show digital clock on the home header
- apply new theme colors across analysis and event screens

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684188bcd3dc8329a0803561d433a100