### PR TITLE
Add Sleep tab and updated navigation

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -6,9 +6,10 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'providers/sleep_tracking_provider.dart';
-import 'screens/home_screen.dart';
+import 'screens/sleep_tab_screen.dart';
+import 'screens/sleep_history_screen.dart';
 import 'screens/sleep_analysis_screen.dart';
-import 'screens/sound_events_screen.dart';
+import 'screens/profile_screen.dart';
 import 'utils/app_theme.dart';
 
 /// エントリポイント。アプリを起動する
@@ -54,31 +55,36 @@ class _MainScreenState extends State<MainScreen> {
   int _currentIndex = 0;
 
   final List<Widget> _screens = [
-    const HomeScreen(),
+    const SleepTabScreen(),
+    const SleepHistoryScreen(),
     const SleepAnalysisScreen(),
-    const SoundEventsScreen(),
+    const ProfileScreen(),
   ];
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       body: _screens[_currentIndex],
-      bottomNavigationBar: BottomNavigationBar(
-        backgroundColor: AppTheme.background,
-        selectedItemColor: AppTheme.accent,
-        unselectedItemColor: Colors.grey,
-        currentIndex: _currentIndex,
-        onTap: (index) {
-          setState(() {
-            _currentIndex = index;
-          });
-        },
-        items: const [
-          BottomNavigationBarItem(icon: Icon(Icons.home), label: 'ホーム'),
-          BottomNavigationBarItem(icon: Icon(Icons.analytics), label: '分析'),
-          BottomNavigationBarItem(icon: Icon(Icons.volume_up), label: '音声イベント'),
-        ],
-      ),
+      bottomNavigationBar: Provider.of<SleepTrackingProvider>(context).isRecording
+          ? null
+          : BottomNavigationBar(
+              backgroundColor: AppTheme.background,
+              selectedItemColor: AppTheme.accent,
+              unselectedItemColor: Colors.grey,
+              currentIndex: _currentIndex,
+              onTap: (index) {
+                setState(() {
+                  _currentIndex = index;
+                });
+              },
+              items: const [
+                BottomNavigationBarItem(
+                    icon: Icon(Icons.nightlight_round), label: '睡眠'),
+                BottomNavigationBarItem(icon: Icon(Icons.book), label: '日誌'),
+                BottomNavigationBarItem(icon: Icon(Icons.bar_chart), label: '統計'),
+                BottomNavigationBarItem(icon: Icon(Icons.person), label: 'プロフィール'),
+              ],
+            ),
     );
   }
 }

--- a/lib/main_new.dart
+++ b/lib/main_new.dart
@@ -1,11 +1,11 @@
 /// デザインドキュメント
 /// テスト用に機能を絞ったエントリポイント。
-/// - 開発時に HomeScreen のみを表示して動作確認を容易にする
+/// - 開発時に SleepTabScreen のみを表示して動作確認を容易にする
 /// - SleepTrackingProvider の初期化処理は本番と共通でロジックを共有
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'providers/sleep_tracking_provider.dart';
-import 'screens/home_screen.dart';
+import 'screens/sleep_tab_screen.dart';
 import 'utils/app_theme.dart';
 
 /// テスト用エントリポイント
@@ -13,7 +13,7 @@ void main() {
   runApp(const SleepCycleApp());
 }
 
-/// HomeScreen だけを表示する簡易版アプリ
+/// SleepTabScreen だけを表示する簡易版アプリ
 class SleepCycleApp extends StatelessWidget {
   const SleepCycleApp({super.key});
 
@@ -31,7 +31,7 @@ class SleepCycleApp extends StatelessWidget {
           ),
           scaffoldBackgroundColor: AppTheme.background,
         ),
-        home: const HomeScreen(),
+        home: const SleepTabScreen(),
         debugShowCheckedModeBanner: false,
       ),
     );

--- a/lib/screens/profile_screen.dart
+++ b/lib/screens/profile_screen.dart
@@ -1,0 +1,25 @@
+import 'package:flutter/material.dart';
+import '../utils/app_theme.dart';
+
+class ProfileScreen extends StatelessWidget {
+  const ProfileScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: AppTheme.background,
+      appBar: AppBar(
+        title: const Text('プロフィール'),
+        backgroundColor: AppTheme.cardBackground,
+        foregroundColor: Colors.white,
+        elevation: 0,
+      ),
+      body: const Center(
+        child: Text(
+          'プロフィール情報',
+          style: TextStyle(color: Colors.white),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/sleep_tab_screen.dart
+++ b/lib/screens/sleep_tab_screen.dart
@@ -1,0 +1,161 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import '../providers/sleep_tracking_provider.dart';
+import '../utils/app_theme.dart';
+
+class SleepTabScreen extends StatefulWidget {
+  const SleepTabScreen({super.key});
+
+  @override
+  State<SleepTabScreen> createState() => _SleepTabScreenState();
+}
+
+class _SleepTabScreenState extends State<SleepTabScreen> {
+  DateTime _wakeUpTime = DateTime.now().add(const Duration(hours: 8));
+
+  String _formatTime(DateTime time) {
+    return '${time.hour.toString().padLeft(2, '0')}:${time.minute.toString().padLeft(2, '0')}';
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Consumer<SleepTrackingProvider>(
+      builder: (context, provider, child) {
+        final isSleeping = provider.isRecording;
+        final rangeStart = _wakeUpTime;
+        final rangeEnd = _wakeUpTime.add(const Duration(minutes: 30));
+        final rangeText = '${_formatTime(rangeStart)}-${_formatTime(rangeEnd)}';
+
+        return Scaffold(
+          backgroundColor: Colors.transparent,
+          body: Container(
+            decoration: BoxDecoration(
+              gradient: LinearGradient(
+                begin: Alignment.topCenter,
+                end: Alignment.bottomCenter,
+                colors: isSleeping
+                    ? [Colors.black, const Color(0xFF0A0A23)]
+                    : [const Color(0xFF001027), Colors.black],
+              ),
+            ),
+            child: SafeArea(
+              child: Stack(
+                children: [
+                  if (!isSleeping)
+                    _buildSetup(context, provider, rangeText)
+                  else
+                    _buildSleepMode(context, provider, rangeText),
+                ],
+              ),
+            ),
+          ),
+        );
+      },
+    );
+  }
+
+  Widget _buildSetup(
+      BuildContext context, SleepTrackingProvider provider, String rangeText) {
+    return Column(
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: [
+        SizedBox(
+          height: 200,
+          child: CupertinoDatePicker(
+            mode: CupertinoDatePickerMode.time,
+            use24hFormat: true,
+            initialDateTime: _wakeUpTime,
+            onDateTimeChanged: (value) {
+              setState(() {
+                _wakeUpTime = value;
+              });
+            },
+          ),
+        ),
+        const SizedBox(height: 24),
+        Text(
+          '次の時間帯に簡単に起床 $rangeText',
+          style: const TextStyle(color: Colors.white, fontSize: 16),
+        ),
+        const SizedBox(height: 40),
+        GestureDetector(
+          onTap: provider.startSleepTracking,
+          child: Container(
+            padding: const EdgeInsets.symmetric(horizontal: 40, vertical: 16),
+            decoration: BoxDecoration(
+              color: Colors.black,
+              borderRadius: BorderRadius.circular(30),
+              boxShadow: const [
+                BoxShadow(
+                  color: Colors.white24,
+                  blurRadius: 8,
+                  offset: Offset(0, 4),
+                ),
+              ],
+            ),
+            child: const Text(
+              '開始',
+              style: TextStyle(color: Colors.white, fontSize: 20),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildSleepMode(
+      BuildContext context, SleepTrackingProvider provider, String rangeText) {
+    return Column(
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: [
+        StreamBuilder<DateTime>(
+          stream: Stream.periodic(
+            const Duration(seconds: 1),
+            (_) => DateTime.now(),
+          ),
+          builder: (context, snapshot) {
+            final now = snapshot.data ?? DateTime.now();
+            final time =
+                '${now.hour.toString().padLeft(2, '0')}:${now.minute.toString().padLeft(2, '0')}';
+            return Text(
+              time,
+              style: const TextStyle(
+                fontSize: 48,
+                color: Colors.white,
+              ),
+            );
+          },
+        ),
+        const SizedBox(height: 16),
+        Text(
+          '次の時間帯に簡単に起床 $rangeText',
+          style: const TextStyle(color: Colors.white70, fontSize: 16),
+        ),
+        const Spacer(),
+        GestureDetector(
+          onTap: provider.stopSleepTracking,
+          child: Container(
+            padding: const EdgeInsets.symmetric(horizontal: 40, vertical: 16),
+            margin: const EdgeInsets.only(bottom: 40),
+            decoration: BoxDecoration(
+              color: Colors.black,
+              borderRadius: BorderRadius.circular(30),
+              boxShadow: const [
+                BoxShadow(
+                  color: Colors.white24,
+                  blurRadius: 8,
+                  offset: Offset(0, 4),
+                ),
+              ],
+            ),
+            child: const Text(
+              '停止',
+              style: TextStyle(color: Colors.white, fontSize: 20),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- implement `SleepTabScreen` with wake time picker and sleep mode
- hide bottom bar while recording and update nav items
- add simple profile screen
- update test main entry

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68430bc67fcc83298609df0903d7cf5a