### PR TITLE
Improve wake up picker usability

### DIFF
--- a/lib/screens/sleep_tab_screen.dart
+++ b/lib/screens/sleep_tab_screen.dart
@@ -65,6 +65,7 @@ class _SleepTabScreenState extends State<SleepTabScreen> {
           child: CupertinoDatePicker(
             mode: CupertinoDatePickerMode.time,
             use24hFormat: true,
+            minuteInterval: 5,
             initialDateTime: _wakeUpTime,
             onDateTimeChanged: (value) {
               setState(() {


### PR DESCRIPTION
## Summary
- adjust the wake up time picker to allow selecting minutes in 5-minute steps

## Testing
- `flutter --version` *(fails: command not found)*
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68430e28b23083298db7e48d5ae626f4